### PR TITLE
MS-1300: use tempfile instead of PIPE

### DIFF
--- a/encrypt-and-upload.py
+++ b/encrypt-and-upload.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import datetime
@@ -13,6 +13,7 @@ import shutil
 import subprocess
 import sys
 import tarfile
+import tempfile
 import time
 import yaml
 
@@ -151,9 +152,10 @@ class Uploader(multiprocessing.Process):
       logger.debug('%s: %s' % (proc_name, ' '.join(command)))
       if not config['dry_run']:
         if len(command) > 0:
-          process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-          output, _ = process.communicate()
-          logger.info(output)
+          with tempfile.NamedTemporaryFile() as tmpfile:
+            process = subprocess.Popen(command, stdout=tmpfile, stderr=subprocess.STDOUT)
+            exitcode = process.wait()
+            logger.info(tmpfile.readlines())
       else:
         time.sleep(random.random() * 0.1)
 


### PR DESCRIPTION
In `subprocess.Popen`, replace the usage of `stdout=subprocess.PIPE`with `stdout=tmpfile` using a `tempfile.NamedTemporaryFile()`.
Reason for this is an issue described in http://thraxil.org/users/anders/posts/2008/03/13/Subprocess-Hanging-PIPE-is-your-enemy/. The progress of `aws s3 cp` wrote a new line after a few KiloBytes:
```2022-09-12 12:42:30,456 - INFO - Completed 256.0 KiB/59.6 MiB (921.9 KiB/s) with 1 file(s) remaining^MCompleted 512.0 KiB/59.6 MiB (1.7 MiB/s) with 1 file(s) remaining  ^MCompleted 768.0 KiB/59.6 MiB (2.6 MiB/s) with 1 file(s) remaining```
When uploading bigger files, this leads to a very long string causing python to hang without a notice.